### PR TITLE
Proof of concept - API design

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,7 @@
 # Used by "mix format"
 [
+  locals_without_parens: [
+    on_exit: 1
+  ],
   inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,1 +1,4 @@
 use Mix.Config
+
+config :events,
+  impl: Events.Impl.Agent

--- a/lib/events.ex
+++ b/lib/events.ex
@@ -52,7 +52,7 @@ defmodule Events do
   def execute(event_name, value) when is_number(value) do
     assert_event_name_or_prefix(event_name)
 
-    handlers = @callback_mod.list_attached_to(event_name)
+    handlers = @callback_mod.list_handlers_for_event(event_name)
 
     for {handler_id, _, module, function, config} <- handlers do
       try do
@@ -75,7 +75,7 @@ defmodule Events do
   def list_handlers(event_prefix) do
     assert_event_name_or_prefix(event_prefix)
 
-    @callback_mod.list_handlers(event_prefix)
+    @callback_mod.list_handlers_by_prefix(event_prefix)
   end
 
   @doc false

--- a/lib/events.ex
+++ b/lib/events.ex
@@ -16,7 +16,7 @@ defmodule Events do
   Creates a subscription to an event.
 
   `subscription_id` must be unique, if another subscription with the same ID already exists the
-  `:error` atom is be returned.
+  `{:error, :already_exists}` atom is be returned.
 
   When events with `event_prefix` are emitted, function `function` in module `module` will be
   called with three arguments:
@@ -26,17 +26,18 @@ defmodule Events do
 
   If the function fails (raises, exits or throws) then the subscription is removed.
   """
-  @spec subscribe(subscription_id, event_prefix, module, function :: atom) :: :ok | :error
+  @spec subscribe(subscription_id, event_prefix, module, function :: atom) ::
+          :ok | {:error, :already_exists}
   @spec subscribe(subscription_id, event_prefix, module, function :: atom, config :: term) ::
-          :ok | :error
+          :ok | {:error, :already_exists}
   defdelegate subscribe(sub_id, event_prefix, module, function, config \\ nil), to: @callback_mod
 
   @doc """
   Removes existing subscription.
 
-  If the subscription doesn't exist, `:error` is returned.
+  If the subscription doesn't exist, `{:error, :not_found}` is returned.
   """
-  @spec unsubscribe(subscription_id) :: :ok | :error
+  @spec unsubscribe(subscription_id) :: :ok | {:error, :not_found}
   defdelegate unsubscribe(sub_id), to: @callback_mod
 
   @doc """

--- a/lib/events.ex
+++ b/lib/events.ex
@@ -1,74 +1,72 @@
 defmodule Events do
   @moduledoc """
-  Events allows to subscribe functions to events, and call these functions when the events are
-  emitted.
+  Events allows to attach functions to be called when events are emitted
 
   Note that all subscribed functions are called in the process which emits the event.
   """
 
   @callback_mod Application.fetch_env!(:events, :impl)
 
-  @type subscription_id :: term()
+  @type handler_id :: term()
   @type event_name :: list()
   @type event_prefix :: list()
 
   @doc """
-  Creates a subscription to an event.
+  Attaches a handler to the event prefix.
 
-  `subscription_id` must be unique, if another subscription with the same ID already exists the
-  `{:error, :already_exists}` atom is be returned.
+  `handler_id` must be unique, if another handler with the same ID already exists the
+  `{:error, :already_exists}` tuple is returned.
 
   When events with `event_prefix` are emitted, function `function` in module `module` will be
   called with three arguments:
-  * the exact event name (see `emit/2`)
-  * the event value (see `emit/2`)
-  * the subscription configuration, `config`, or `nil` if one wasn't provided
+  * the exact event name (see `execute/2`)
+  * the event value (see `execute/2`)
+  * the handler configuration, `config`, or `nil` if one wasn't provided
 
-  If the function fails (raises, exits or throws) then the subscription is removed.
+  If the function fails (raises, exits or throws) then the handler is removed.
   """
-  @spec subscribe(subscription_id, event_prefix, module, function :: atom) ::
+  @spec attach(handler_id, event_prefix, module, function :: atom) ::
           :ok | {:error, :already_exists}
-  @spec subscribe(subscription_id, event_prefix, module, function :: atom, config :: term) ::
+  @spec attach(handler_id, event_prefix, module, function :: atom, config :: term) ::
           :ok | {:error, :already_exists}
-  defdelegate subscribe(sub_id, event_prefix, module, function, config \\ nil), to: @callback_mod
+  defdelegate attach(handler_id, event_prefix, module, function, config \\ nil), to: @callback_mod
 
   @doc """
-  Removes existing subscription.
+  Removes existing handler.
 
-  If the subscription doesn't exist, `{:error, :not_found}` is returned.
+  If the handler with given ID doesn't exist, `{:error, :not_found}` is returned.
   """
-  @spec unsubscribe(subscription_id) :: :ok | {:error, :not_found}
-  defdelegate unsubscribe(sub_id), to: @callback_mod
+  @spec detach(handler_id) :: :ok | {:error, :not_found}
+  defdelegate detach(handler_id), to: @callback_mod
 
   @doc """
-  Emits an event with given name and value.
+  Emits an event, executing handlers attached to all of its prefixes.
 
-  All functions subscribed to the prefix of the `event_name` will be called. Note that you should
-  not rely on the order in which those functions are called.
+  Note that you should not rely on the order in which those functions are called.
   """
-  @spec emit(event_name, value :: term()) :: :ok
-  def emit(event_name, value) do
-    subscribed = @callback_mod.list_subscribed_to(event_name)
+  @spec execute(event_name, value :: term()) :: :ok
+  def execute(event_name, value) do
+    handlers = @callback_mod.list_attached_to(event_name)
 
-    for {sub_id, _, module, function, config} <- subscribed do
+    for {handler_id, _, module, function, config} <- handlers do
       try do
         apply(module, function, [event_name, value, config])
       catch
         _, _ ->
-          # it might happen that other processes will call it before it's unsubscribed
-          unsubscribe(sub_id)
+          # it might happen that other processes will call it before it's detached
+          detach(handler_id)
       end
     end
   end
 
   @doc """
-  Returns all subscriptions to events with given prefix.
+  Returns all handlers attached to events with given prefix.
 
-  Note that you can list all subscriptions by feeding this function an empty list.
+  Note that you can list all handlers by feeding this function an empty list.
   """
-  @spec list_subscriptions(event_prefix) ::
-          {subscription_id, event_prefix, module, function :: atom, config :: map}
-  defdelegate list_subscriptions(event_prefix), to: @callback_mod
+  @spec list_handlers(event_prefix) ::
+          {handler_id, event_prefix, module, function :: atom, config :: map}
+  defdelegate list_handlers(event_prefix), to: @callback_mod
 
   @doc false
   defdelegate child_spec(term), to: @callback_mod

--- a/lib/events.ex
+++ b/lib/events.ex
@@ -1,3 +1,61 @@
 defmodule Events do
-  @moduledoc false
+  @moduledoc """
+  Events allows to subscribe functions to events, and call these functions when the events are
+  emitted.
+
+  Note that all subscribed functions are called in the process which emits the event.
+  """
+
+  @type subscription_id :: term()
+  @type event_name :: list()
+  @type event_prefix :: list()
+
+  @doc """
+  Creates a subscription to an event.
+
+  `subscription_id` must be unique, if another subscription with the same ID already exists the
+  `:error` atom is be returned.
+
+  When events with `event_prefix` are emitted, function `function` in module `module` will be
+  called with three arguments:
+  * the exact event name (see `emit/2`)
+  * the event value (see `emit/2`)
+  * the subscription configuration, `config`, or an empty map if one wasn't provided
+
+  If the function fails (raises, exits or throws) then the subscription is removed.
+  """
+  @spec subscribe(subscription_id, event_prefix, module, function :: atom) :: :ok | :error
+  @spec subscribe(subscription_id, event_prefix, module, function :: atom, config :: map) ::
+          :ok | :error
+  def subscribe(sub_id, event_prefix, module, function, config \\ %{}) do
+  end
+
+  @doc """
+  Removes existing subscription.
+
+  If the subscription doesn't exist, `:error` is returned.
+  """
+  @spec unsubscribe(subscription_id) :: :ok | :error
+  def unsubscribe(sub_id) do
+  end
+
+  @doc """
+  Emits an event with given name and value.
+
+  All functions subscribed to the prefix of the `event_name` will be called. Note that you should
+  not rely on the order in which those functions are called.
+  """
+  @spec emit(event_name, value :: term()) :: :ok
+  def emit(event_name, value) do
+  end
+
+  @doc """
+  Returns all subscriptions to events with given prefix.
+
+  Note that you can list all subscriptions by feeding this function an empty list.
+  """
+  @spec list_subscriptions(event_prefix) ::
+          {subscription_id, event_prefix, module, function :: atom, config :: map}
+  def list_subscriptions(event_prefix) do
+  end
 end

--- a/lib/events.ex
+++ b/lib/events.ex
@@ -6,6 +6,8 @@ defmodule Events do
   Note that all subscribed functions are called in the process which emits the event.
   """
 
+  @callback_mod Application.fetch_env!(:events, :impl)
+
   @type subscription_id :: term()
   @type event_name :: list()
   @type event_prefix :: list()
@@ -27,7 +29,7 @@ defmodule Events do
   @spec subscribe(subscription_id, event_prefix, module, function :: atom) :: :ok | :error
   @spec subscribe(subscription_id, event_prefix, module, function :: atom, config :: term) ::
           :ok | :error
-  defdelegate subscribe(sub_id, event_prefix, module, function, config \\ nil), to: Events.Impl
+  defdelegate subscribe(sub_id, event_prefix, module, function, config \\ nil), to: @callback_mod
 
   @doc """
   Removes existing subscription.
@@ -35,7 +37,7 @@ defmodule Events do
   If the subscription doesn't exist, `:error` is returned.
   """
   @spec unsubscribe(subscription_id) :: :ok | :error
-  defdelegate unsubscribe(sub_id), to: Events.Impl
+  defdelegate unsubscribe(sub_id), to: @callback_mod
 
   @doc """
   Emits an event with given name and value.
@@ -45,7 +47,7 @@ defmodule Events do
   """
   @spec emit(event_name, value :: term()) :: :ok
   def emit(event_name, value) do
-    subscribed = Events.Impl.list_subscribed_to(event_name)
+    subscribed = @callback_mod.list_subscribed_to(event_name)
 
     for {sub_id, _, module, function, config} <- subscribed do
       try do
@@ -65,5 +67,8 @@ defmodule Events do
   """
   @spec list_subscriptions(event_prefix) ::
           {subscription_id, event_prefix, module, function :: atom, config :: map}
-  defdelegate list_subscriptions(event_prefix), to: Events.Impl
+  defdelegate list_subscriptions(event_prefix), to: @callback_mod
+
+  @doc false
+  defdelegate child_spec(term), to: @callback_mod
 end

--- a/lib/events.ex
+++ b/lib/events.ex
@@ -9,6 +9,7 @@ defmodule Events do
 
   @type handler_id :: term()
   @type event_name :: list()
+  @type event_value :: number()
   @type event_prefix :: list()
 
   @doc """
@@ -44,8 +45,8 @@ defmodule Events do
 
   Note that you should not rely on the order in which those functions are called.
   """
-  @spec execute(event_name, value :: term()) :: :ok
-  def execute(event_name, value) do
+  @spec execute(event_name, event_value) :: :ok
+  def execute(event_name, value) when is_number(value) do
     handlers = @callback_mod.list_attached_to(event_name)
 
     for {handler_id, _, module, function, config} <- handlers do

--- a/lib/events/application.ex
+++ b/lib/events/application.ex
@@ -5,7 +5,7 @@ defmodule Events.Application do
 
   def start(_type, _args) do
     children = [
-      Events.Impl
+      Events
     ]
 
     opts = [strategy: :one_for_one, name: Events.Supervisor]

--- a/lib/events/application.ex
+++ b/lib/events/application.ex
@@ -4,7 +4,9 @@ defmodule Events.Application do
   use Application
 
   def start(_type, _args) do
-    children = []
+    children = [
+      Events.Impl
+    ]
 
     opts = [strategy: :one_for_one, name: Events.Supervisor]
     Supervisor.start_link(children, opts)

--- a/lib/events/impl.ex
+++ b/lib/events/impl.ex
@@ -3,21 +3,21 @@ defmodule Events.Impl do
 
   @callback child_spec(term()) :: Supervisor.child_spec()
 
-  @callback subscribe(
-              Events.subscription_id(),
+  @callback attach(
+              Events.handler_id(),
               Events.event_prefix(),
               module,
               function :: atom,
               config :: map
             ) :: :ok | {:error, :already_exists}
 
-  @callback unsubscribe(Events.subscription_id()) :: :ok | {:error, :not_found}
+  @callback detach(Events.handler_id()) :: :ok | {:error, :not_found}
 
-  @callback list_subscribed_to(Events.event_name()) ::
-              {Events.subscription_id(), Events.event_prefix(), module, function :: atom,
+  @callback list_attached_to(Events.event_name()) ::
+              {Events.handler_id(), Events.event_prefix(), module, function :: atom,
                config :: term}
 
-  @callback list_subscriptions(Events.event_prefix()) ::
-              {Events.subscription_id(), Events.event_prefix(), module, function :: atom,
+  @callback list_handlers(Events.event_prefix()) ::
+              {Events.handler_id(), Events.event_prefix(), module, function :: atom,
                config :: term}
 end

--- a/lib/events/impl.ex
+++ b/lib/events/impl.ex
@@ -1,0 +1,37 @@
+defmodule Events.Impl do
+  @moduledoc false
+
+  defmodule Callbacks do
+    @callback child_spec(term()) :: Supervisor.child_spec()
+
+    @callback subscribe(
+                Events.subscription_id(),
+                Events.event_prefix(),
+                module,
+                function :: atom,
+                config :: map
+              ) :: :ok | :error
+
+    @callback unsubscribe(Events.subscription_id()) :: :ok | :error
+
+    @callback list_subscribed_to(Events.event_name()) ::
+                {Events.subscription_id(), Events.event_prefix(), module, function :: atom,
+                 config :: term}
+
+    @callback list_subscriptions(Events.event_prefix()) ::
+                {Events.subscription_id(), Events.event_prefix(), module, function :: atom,
+                 config :: term}
+  end
+
+  @callback_mod Application.fetch_env!(:events, :impl)
+
+  defdelegate child_spec(term), to: @callback_mod
+
+  defdelegate subscribe(sub_id, prefix, module, function, config), to: @callback_mod
+
+  defdelegate unsubscribe(sub_id), to: @callback_mod
+
+  defdelegate list_subscribed_to(event), to: @callback_mod
+
+  defdelegate list_subscriptions(prefix), to: @callback_mod
+end

--- a/lib/events/impl.ex
+++ b/lib/events/impl.ex
@@ -1,37 +1,23 @@
 defmodule Events.Impl do
   @moduledoc false
 
-  defmodule Callbacks do
-    @callback child_spec(term()) :: Supervisor.child_spec()
+  @callback child_spec(term()) :: Supervisor.child_spec()
 
-    @callback subscribe(
-                Events.subscription_id(),
-                Events.event_prefix(),
-                module,
-                function :: atom,
-                config :: map
-              ) :: :ok | :error
+  @callback subscribe(
+              Events.subscription_id(),
+              Events.event_prefix(),
+              module,
+              function :: atom,
+              config :: map
+            ) :: :ok | :error
 
-    @callback unsubscribe(Events.subscription_id()) :: :ok | :error
+  @callback unsubscribe(Events.subscription_id()) :: :ok | :error
 
-    @callback list_subscribed_to(Events.event_name()) ::
-                {Events.subscription_id(), Events.event_prefix(), module, function :: atom,
-                 config :: term}
+  @callback list_subscribed_to(Events.event_name()) ::
+              {Events.subscription_id(), Events.event_prefix(), module, function :: atom,
+               config :: term}
 
-    @callback list_subscriptions(Events.event_prefix()) ::
-                {Events.subscription_id(), Events.event_prefix(), module, function :: atom,
-                 config :: term}
-  end
-
-  @callback_mod Application.fetch_env!(:events, :impl)
-
-  defdelegate child_spec(term), to: @callback_mod
-
-  defdelegate subscribe(sub_id, prefix, module, function, config), to: @callback_mod
-
-  defdelegate unsubscribe(sub_id), to: @callback_mod
-
-  defdelegate list_subscribed_to(event), to: @callback_mod
-
-  defdelegate list_subscriptions(prefix), to: @callback_mod
+  @callback list_subscriptions(Events.event_prefix()) ::
+              {Events.subscription_id(), Events.event_prefix(), module, function :: atom,
+               config :: term}
 end

--- a/lib/events/impl.ex
+++ b/lib/events/impl.ex
@@ -9,9 +9,9 @@ defmodule Events.Impl do
               module,
               function :: atom,
               config :: map
-            ) :: :ok | :error
+            ) :: :ok | {:error, :already_exists}
 
-  @callback unsubscribe(Events.subscription_id()) :: :ok | :error
+  @callback unsubscribe(Events.subscription_id()) :: :ok | {:error, :not_found}
 
   @callback list_subscribed_to(Events.event_name()) ::
               {Events.subscription_id(), Events.event_prefix(), module, function :: atom,

--- a/lib/events/impl.ex
+++ b/lib/events/impl.ex
@@ -13,11 +13,11 @@ defmodule Events.Impl do
 
   @callback detach(Events.handler_id()) :: :ok | {:error, :not_found}
 
-  @callback list_attached_to(Events.event_name()) ::
+  @callback list_handlers_for_event(Events.event_name()) ::
               {Events.handler_id(), Events.event_prefix(), module, function :: atom,
                config :: term}
 
-  @callback list_handlers(Events.event_prefix()) ::
+  @callback list_handlers_by_prefix(Events.event_prefix()) ::
               {Events.handler_id(), Events.event_prefix(), module, function :: atom,
                config :: term}
 end

--- a/lib/events/impl/agent.ex
+++ b/lib/events/impl/agent.ex
@@ -13,43 +13,43 @@ defmodule Events.Impl.Agent do
   end
 
   @impl true
-  def subscribe(sub_id, prefix, module, function, config) do
-    Agent.get_and_update(__MODULE__, fn subs ->
-      if Map.has_key?(subs, sub_id) do
-        {{:error, :already_exists}, subs}
+  def attach(handler_id, prefix, module, function, config) do
+    Agent.get_and_update(__MODULE__, fn handlers ->
+      if Map.has_key?(handlers, handler_id) do
+        {{:error, :already_exists}, handlers}
       else
-        {:ok, Map.put(subs, sub_id, {sub_id, prefix, module, function, config})}
+        {:ok, Map.put(handlers, handler_id, {handler_id, prefix, module, function, config})}
       end
     end)
   end
 
   @impl true
-  def unsubscribe(sub_id) do
-    Agent.get_and_update(__MODULE__, fn subs ->
-      if Map.has_key?(subs, sub_id) do
-        {:ok, Map.delete(subs, sub_id)}
+  def detach(handler_id) do
+    Agent.get_and_update(__MODULE__, fn handlers ->
+      if Map.has_key?(handlers, handler_id) do
+        {:ok, Map.delete(handlers, handler_id)}
       else
-        {{:error, :not_found}, subs}
+        {{:error, :not_found}, handlers}
       end
     end)
   end
 
   @impl true
-  def list_subscribed_to(event) do
-    subs = Agent.get(__MODULE__, fn subs -> Map.values(subs) end)
+  def list_attached_to(event) do
+    handlers = Agent.get(__MODULE__, fn handlers -> Map.values(handlers) end)
 
-    Enum.filter(subs, fn {_, prefix, _, _, _} ->
+    Enum.filter(handlers, fn {_, prefix, _, _, _} ->
       Enum.take(event, length(prefix)) == prefix
     end)
   end
 
   @impl true
-  def list_subscriptions(prefix) do
-    subs = Agent.get(__MODULE__, fn subs -> Map.values(subs) end)
+  def list_handlers(prefix) do
+    handlers = Agent.get(__MODULE__, fn handlers -> Map.values(handlers) end)
 
     prefix_len = length(prefix)
 
-    Enum.filter(subs, fn {_, sub_prefix, _, _, _} ->
+    Enum.filter(handlers, fn {_, sub_prefix, _, _, _} ->
       Enum.take(sub_prefix, prefix_len) == prefix
     end)
   end

--- a/lib/events/impl/agent.ex
+++ b/lib/events/impl/agent.ex
@@ -2,7 +2,7 @@ defmodule Events.Impl.Agent do
   @moduledoc false
   # Dummy implementation, not really performant but good for designing the APIs.
 
-  @behaviour Events.Impl.Callbacks
+  @behaviour Events.Impl
 
   @impl true
   def child_spec(_) do

--- a/lib/events/impl/agent.ex
+++ b/lib/events/impl/agent.ex
@@ -16,7 +16,7 @@ defmodule Events.Impl.Agent do
   def subscribe(sub_id, prefix, module, function, config) do
     Agent.get_and_update(__MODULE__, fn subs ->
       if Map.has_key?(subs, sub_id) do
-        {:error, subs}
+        {{:error, :already_exists}, subs}
       else
         {:ok, Map.put(subs, sub_id, {sub_id, prefix, module, function, config})}
       end
@@ -29,7 +29,7 @@ defmodule Events.Impl.Agent do
       if Map.has_key?(subs, sub_id) do
         {:ok, Map.delete(subs, sub_id)}
       else
-        {:error, subs}
+        {{:error, :not_found}, subs}
       end
     end)
   end

--- a/lib/events/impl/agent.ex
+++ b/lib/events/impl/agent.ex
@@ -35,7 +35,7 @@ defmodule Events.Impl.Agent do
   end
 
   @impl true
-  def list_attached_to(event) do
+  def list_handlers_for_event(event) do
     handlers = Agent.get(__MODULE__, fn handlers -> Map.values(handlers) end)
 
     Enum.filter(handlers, fn {_, prefix, _, _, _} ->
@@ -44,7 +44,7 @@ defmodule Events.Impl.Agent do
   end
 
   @impl true
-  def list_handlers(prefix) do
+  def list_handlers_by_prefix(prefix) do
     handlers = Agent.get(__MODULE__, fn handlers -> Map.values(handlers) end)
 
     prefix_len = length(prefix)

--- a/lib/events/impl/agent.ex
+++ b/lib/events/impl/agent.ex
@@ -1,0 +1,56 @@
+defmodule Events.Impl.Agent do
+  @moduledoc false
+  # Dummy implementation, not really performant but good for designing the APIs.
+
+  @behaviour Events.Impl.Callbacks
+
+  @impl true
+  def child_spec(_) do
+    %{
+      id: __MODULE__,
+      start: {Agent, :start_link, [fn -> %{} end, [name: __MODULE__]]}
+    }
+  end
+
+  @impl true
+  def subscribe(sub_id, prefix, module, function, config) do
+    Agent.get_and_update(__MODULE__, fn subs ->
+      if Map.has_key?(subs, sub_id) do
+        {:error, subs}
+      else
+        {:ok, Map.put(subs, sub_id, {sub_id, prefix, module, function, config})}
+      end
+    end)
+  end
+
+  @impl true
+  def unsubscribe(sub_id) do
+    Agent.get_and_update(__MODULE__, fn subs ->
+      if Map.has_key?(subs, sub_id) do
+        {:ok, Map.delete(subs, sub_id)}
+      else
+        {:error, subs}
+      end
+    end)
+  end
+
+  @impl true
+  def list_subscribed_to(event) do
+    subs = Agent.get(__MODULE__, fn subs -> Map.values(subs) end)
+
+    Enum.filter(subs, fn {_, prefix, _, _, _} ->
+      Enum.take(event, length(prefix)) == prefix
+    end)
+  end
+
+  @impl true
+  def list_subscriptions(prefix) do
+    subs = Agent.get(__MODULE__, fn subs -> Map.values(subs) end)
+
+    prefix_len = length(prefix)
+
+    Enum.filter(subs, fn {_, sub_prefix, _, _, _} ->
+      Enum.take(sub_prefix, prefix_len) == prefix
+    end)
+  end
+end

--- a/test/events_test.exs
+++ b/test/events_test.exs
@@ -1,3 +1,120 @@
 defmodule EventsTest do
   use ExUnit.Case
+
+  defmodule TestSubscriber do
+    def echo_event(event, value, %{send_to: pid} = config) do
+      send(pid, {:event, event, value, config})
+    end
+
+    def raise_on_event(_event, _value, _config) do
+      raise "Got an event"
+    end
+  end
+
+  setup do
+    subscription_id = :crypto.strong_rand_bytes(16) |> Base.encode16()
+
+    on_exit fn ->
+      Events.unsubscribe(subscription_id)
+    end
+
+    {:ok, sub_id: subscription_id}
+  end
+
+  test "subscribing returns error if subscription with the same ID already exist", %{
+    sub_id: sub_id
+  } do
+    :ok = Events.subscribe(sub_id, [:some, :event], TestSubscriber, :echo_event)
+
+    assert :error = Events.subscribe(sub_id, [:some, :event], TestSubscriber, :echo_event)
+  end
+
+  test "subscribed mf is called when event exactly matches the subscription prefix", %{
+    sub_id: sub_id
+  } do
+    event = [:a, :test, :event]
+    config = %{send_to: self()}
+    value = 1
+    Events.subscribe(sub_id, event, TestSubscriber, :echo_event, config)
+
+    Events.emit(event, value)
+
+    assert_receive {:event, ^event, ^value, ^config}
+  end
+
+  test "subscribed mf is not called when event is a prefix of the subscription prefix", %{
+    sub_id: sub_id
+  } do
+    event = [:a, :test]
+    prefix = event ++ [:prefix]
+    config = %{send_to: self()}
+    value = 1
+    Events.subscribe(sub_id, prefix, TestSubscriber, :echo_event, config)
+
+    Events.emit(event, value)
+
+    assert {:messages, []} == Process.info(self(), :messages)
+  end
+
+  test "mf is unsubsribed when it fails", %{sub_id: sub_id} do
+    event = [:a, :test, :event]
+    Events.subscribe(sub_id, event, TestSubscriber, :raise_on_event)
+
+    Events.emit(event, 1)
+
+    assert [] == Events.list_subscriptions(event)
+  end
+
+  test "unsubcribed mf is not called when event is emitted", %{sub_id: sub_id} do
+    event = [:a, :test, :event]
+    Events.subscribe(sub_id, event, TestSubscriber, :echo_event, %{send_to: self()})
+
+    Events.unsubscribe(sub_id)
+    Events.emit(event, 1)
+
+    assert {:messages, []} == Process.info(self(), :messages)
+  end
+
+  test "unsubscribing returns error if subscription doesn't exist", %{
+    sub_id: sub_id
+  } do
+    assert :error = Events.unsubscribe(sub_id)
+  end
+
+  test "mf subscribed to event prefix is called when event is emitted", %{sub_id: sub_id} do
+    prefix = [:a, :test]
+    event = prefix ++ [:event]
+    config = %{send_to: self()}
+    value = 1
+    Events.subscribe(sub_id, prefix, TestSubscriber, :echo_event, config)
+
+    Events.emit(event, value)
+
+    assert_receive {:event, ^event, ^value, ^config}
+  end
+
+  test "subscriptions to event can be listed", %{sub_id: sub_id} do
+    event = [:a, :test, :event]
+    config = %{send_to: self()}
+    Events.subscribe(sub_id, event, TestSubscriber, :echo_event, config)
+
+    assert [{sub_id, event, TestSubscriber, :echo_event, config}] ==
+             Events.list_subscriptions(event)
+  end
+
+  test "subscriptions to event prefix can be listed", %{sub_id: sub_id} do
+    prefix1 = []
+    prefix2 = prefix1 ++ [:a]
+    prefix3 = prefix2 ++ [:test]
+    event = prefix3 ++ [:event]
+    config = %{send_to: self()}
+    Events.subscribe(sub_id, event, TestSubscriber, :echo_event, config)
+
+    for prefix <- [prefix1, prefix2, prefix3] do
+      assert [{sub_id, event, TestSubscriber, :echo_event, config}] ==
+               Events.list_subscriptions(prefix)
+    end
+
+    assert [] == Events.list_subscriptions(event ++ [:something])
+  end
 end

--- a/test/events_test.exs
+++ b/test/events_test.exs
@@ -26,7 +26,8 @@ defmodule EventsTest do
   } do
     :ok = Events.subscribe(sub_id, [:some, :event], TestSubscriber, :echo_event)
 
-    assert :error = Events.subscribe(sub_id, [:some, :event], TestSubscriber, :echo_event)
+    assert {:error, :already_exists} =
+             Events.subscribe(sub_id, [:some, :event], TestSubscriber, :echo_event)
   end
 
   test "subscribed mf is called when event exactly matches the subscription prefix", %{
@@ -78,7 +79,7 @@ defmodule EventsTest do
   test "unsubscribing returns error if subscription doesn't exist", %{
     sub_id: sub_id
   } do
-    assert :error = Events.unsubscribe(sub_id)
+    assert {:error, :not_found} = Events.unsubscribe(sub_id)
   end
 
   test "mf subscribed to event prefix is called when event is emitted", %{sub_id: sub_id} do


### PR DESCRIPTION
The goal of this PR is to discuss the design of the APIs. Implementation is based on Agent, so performance is really crappy, but I've written minimal test suite which should be passing for every future implementation too.

Basic idea is that user can subscribe module and function to an event prefix, and can emit events with some values. Events are always lists of terms, and so are prefixes. When an event is emitted with a value, we look for all the subscriptions whose prefix match the event name, and invoke them like:

```
apply(module, function, [event_name, event_value, config])
```

where `config` is also given when creating a subscription. Each subscription is identified by unique ID, which means that you can subscribe same {module, function} pair many times with different configuration. You can see the API in action in `test/events_test.exs`.

One can also view all subscriptions with prefixes starting with some given sequence (by feeding `list_subscriptions/1` an empty list you get all the subscriptions). 

The naming is of course a subject to discussion. I couldn't come up with anything better than "subscriptions" and "emit". Flaw of the current names is that they're usually associated with exchange of messages and multiple processes while here we have simple function calls.

This PR is a follow up to arkgil/metrics#1.

Ping @josevalim, @chrismccord, @cloud8421, @studzien, @rslota, @mohamedalikhechine.